### PR TITLE
INFRA-6309: Add ability to output into json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ The changelog for Bonvoy
 
 ## Pending Release
 
+* Add `-o json` to output data into a JSON output format
 * Adjust `server restart` to restart the Nomad allocation rather than killing Envoy.
   This allows for a more graceful degradation of traffic to the service.
 * Add cluster filter to `clusters list` to only show a specific cluster

--- a/README.md
+++ b/README.md
@@ -10,11 +10,13 @@ Connect and Nomad environment.
 There are various commands you can run. Usually you are required to pass the
 name of the service you want to query the sidecar for.
 
+All commands have the ability to output in JSON format with: `-o json`
+
 ### Listeners
 
 List all listeners:
 ```bash
-bonvoy listeners auth-grpc
+bonvoy listeners list auth-grpc
 ```
 
 ### Clusters

--- a/commands/output.go
+++ b/commands/output.go
@@ -1,0 +1,28 @@
+package commands
+
+import (
+	"bonvoy/output"
+	"fmt"
+	"github.com/fatih/color"
+)
+
+var green = color.New(color.FgGreen)
+
+func Ok(s ...interface{}) string {
+	return green.Sprintln(s...)
+}
+
+func Info(s ...interface{}) string {
+	return fmt.Sprintln(s...)
+}
+
+func (r *Registry) Output(o interface{}) error {
+	formatter, err := output.NewFormatter(r.GetOutputFormat())
+	if err != nil { return err }
+
+	o, oErr := formatter.Format(o)
+	if oErr != nil { return oErr }
+
+	fmt.Println(o)
+	return nil
+}

--- a/commands/registry.go
+++ b/commands/registry.go
@@ -6,6 +6,9 @@ import (
 	"os"
 )
 
+const outputJson = "json"
+const outputText = "text"
+
 type Registry struct {}
 
 func NewRegistry() *Registry {
@@ -18,6 +21,7 @@ var rootCmd = &cobra.Command{
 }
 
 func (r *Registry) Init() {
+	r.RegisterGlobalFlags()
 	r.RegisterCommands()
 	if err := rootCmd.Execute(); err != nil {
 		_, _ = fmt.Fprintln(os.Stderr, err)
@@ -35,4 +39,20 @@ func (r *Registry) RegisterCommands() {
 	rootCmd.AddCommand(r.Config().Command)
 	rootCmd.AddCommand(r.Statistics().Command)
 	rootCmd.AddCommand(r.Version().Command)
+}
+
+func (r *Registry) RegisterGlobalFlags() {
+	rootCmd.PersistentFlags().StringP("output", "o", "", "Optional output format flag. Accepts: 'json'")
+}
+
+func (r *Registry) IsJsonOutput() bool {
+	return r.GetOutputFormat() == outputJson
+}
+
+// Get the desired output format
+func (r *Registry) GetOutputFormat() string {
+	format, err := rootCmd.PersistentFlags().GetString("output")
+	if err != nil || format != outputJson { return outputText }
+
+	return outputJson
 }

--- a/commands/version.go
+++ b/commands/version.go
@@ -2,12 +2,19 @@ package commands
 
 import (
 	"bonvoy/version"
-	"fmt"
 	"github.com/spf13/cobra"
 )
 
 type Version struct {
 	Command *cobra.Command
+}
+
+type GetVersionResponse struct {
+	Version string `json:"version"`
+}
+
+func (pi GetVersionResponse) String() string {
+	return pi.Version
 }
 
 func (r *Registry) Version() *Version {
@@ -17,8 +24,10 @@ func (r *Registry) Version() *Version {
 			Short: "Display Bonvoy version",
 			Long:  `Display the Bonvoy CLI version`,
 			RunE: func(cmd *cobra.Command, args []string) error {
-				fmt.Println(version.Version)
-				return nil
+				pi := GetVersionResponse{
+					Version: version.Version,
+				}
+				return r.Output(pi)
 			},
 		},
 	}

--- a/envoy/certificates.go
+++ b/envoy/certificates.go
@@ -67,7 +67,7 @@ func (c *Certificates) Get() (CertsResponse, error) {
 type ExpiredCertificate struct {
 	ServiceName string
 	Pid int
-	Envoy *Instance
+	Envoy *Instance `json:"-"`
 	EnvoyExpiration string
 	EnvoyDaysUntilExpiration int
 	ConsulExpiration string

--- a/envoy/clusters.go
+++ b/envoy/clusters.go
@@ -25,50 +25,50 @@ func (i *Instance) Clusters() *Clusters {
 
 
 type ClusterStatistics struct {
-	Host string
-	Outlier ClusterOutlierStatistics
-	DefaultPriority ClusterPriorityStatistics
-	HighPriority ClusterPriorityStatistics
-	AddedViaApi bool
-	Instances map[string]ClusterInstance
+	Host string `json:"host"`
+	Outlier ClusterOutlierStatistics `json:"outlier"`
+	DefaultPriority ClusterPriorityStatistics `json:"default_priority"`
+	HighPriority ClusterPriorityStatistics `json:"high_priority"`
+	AddedViaApi bool `json:"added_via_api"`
+	Instances map[string]ClusterInstance `json:"instances"`
 }
 type ClusterInstance struct {
-	Hostname string
-	Connections ClusterConnectionStatistics
-	Requests ClusterRequestStatistics
-	HealthFlags string
-	Weight int
-	Region string
-	Zone string
-	SubZone string
-	Canary bool
-	Priority int
-	SuccessRate string
-	LocalOriginSuccessRate string
+	Hostname string `json:"hostname"`
+	Connections ClusterConnectionStatistics `json:"connections"`
+	Requests ClusterRequestStatistics `json:"requests"`
+	HealthFlags string `json:"health_flags"`
+	Weight int `json:"weight"`
+	Region string `json:"region"`
+	Zone string `json:"zone"`
+	SubZone string `json:"sub_zone"`
+	Canary bool `json:"canary"`
+	Priority int `json:"priority"`
+	SuccessRate string `json:"success_rate"`
+	LocalOriginSuccessRate string `json:"local_origin_success_rate"`
 }
 type ClusterOutlierStatistics struct {
-	SuccessRateAverage string
-	SuccessRateEjectionThreshold string
-	LocalOriginSuccessRateAverage string
-	LocalOriginSuccessRateEjectionThreshold string
+	SuccessRateAverage string `json:"success_rate_average"`
+	SuccessRateEjectionThreshold string `json:"success_rate_ejection_threshold"`
+	LocalOriginSuccessRateAverage string `json:"local_origin_success_rate_average"`
+	LocalOriginSuccessRateEjectionThreshold string `json:"local_origin_success_rate_ejection_threshold"`
 }
 type ClusterPriorityStatistics struct {
-	MaxConnections int
-	MaxPendingRequests int
-	MaxRequests int
-	MaxRetries int
+	MaxConnections int `json:"max_connections"`
+	MaxPendingRequests int `json:"max_pending_requests"`
+	MaxRequests int `json:"max_requests"`
+	MaxRetries int `json:"max_retries"`
 }
 type ClusterConnectionStatistics struct {
-	Active int
-	Failed int
-	Total int
+	Active int `json:"active"`
+	Failed int `json:"failed"`
+	Total int `json:"total"`
 }
 type ClusterRequestStatistics struct {
-	Active int
-	Error int
-	Success int
-	Timeout int
-	Total int
+	Active int `json:"active"`
+	Error int `json:"error"`
+	Success int `json:"success"`
+	Timeout int `json:"timeout"`
+	Total int `json:"total"`
 }
 
 func (c *Clusters) GetStatistics(specific string) (map[string]ClusterStatistics, error) {

--- a/envoy/instance.go
+++ b/envoy/instance.go
@@ -11,10 +11,10 @@ import (
 )
 
 type Instance struct {
-	Address string
-	Pid int
-	NomadAllocationID string
-	Nomad nomad.Client
+	Address string `json:"-"`
+	Pid int `json:"pid"`
+	NomadAllocationID string `json:"nomad_allocation_id"`
+	Nomad nomad.Client `json:"-"`
 	docker docker.Client
 	nsenter nsenter.Client
 }

--- a/envoy/listeners.go
+++ b/envoy/listeners.go
@@ -23,8 +23,8 @@ func (i *Instance) Listeners() *Listeners {
 }
 
 type Listener struct {
-	Name string
-	TargetAddress string
+	Name string `json:"name"`
+	TargetAddress string `json:"address"`
 }
 
 func (l *Listeners) Get() ([]Listener, error) {

--- a/envoy/logging.go
+++ b/envoy/logging.go
@@ -1,9 +1,5 @@
 package envoy
 
-import (
-	"fmt"
-)
-
 type Logging struct {
 	i *Instance
 	endpoints LoggingEndpoints
@@ -21,10 +17,9 @@ func (i *Instance) Logging() *Logging {
 	}
 }
 
-func (l *Logging) SetLevel(level string) error {
+func (l *Logging) SetLevel(level string) (string, error) {
 	result, err := l.i.nsenter.Curl("-X", "POST", l.endpoints.logging + "?level="+level)
-	if err != nil { return err }
+	if err != nil { return "", err }
 
-	fmt.Println(result)
-	return nil
+	return result, nil
 }

--- a/envoy/server.go
+++ b/envoy/server.go
@@ -88,10 +88,10 @@ func (l *Server) Memory() (ServerMemoryJson, error) {
 }
 
 type ServerMemoryJson struct {
-	Allocated string 			`json:"allocated"`
-	HeapSize string				`json:"heap_size"`
-	PageHeapUnmapped string 	`json:"pageheap_unmapped"`
-	PageHeapFree string 		`json:"pageheap_free"`
-	TotalThreadCache string 	`json:"total_thread_cache"`
-	TotalPhysicalBytes string 	`json:"total_physical_bytes"`
+	Allocated int 			`json:"allocated,string"`
+	HeapSize int			`json:"heap_size,string"`
+	PageHeapUnmapped int 	`json:"pageheap_unmapped,string"`
+	PageHeapFree int 		`json:"pageheap_free,string"`
+	TotalThreadCache int 	`json:"total_thread_cache,string"`
+	TotalPhysicalBytes int 	`json:"total_physical_bytes,string"`
 }

--- a/envoy/statistics.go
+++ b/envoy/statistics.go
@@ -1,5 +1,10 @@
 package envoy
 
+import (
+	"sort"
+	"strings"
+)
+
 type Statistics struct {
 	i *Instance
 	endpoints StatisticsEndpoints
@@ -22,4 +27,30 @@ func (l *Statistics) Dump() (string, error) {
 	if err != nil { return "", err }
 
 	return result, nil
+}
+
+type Statistic struct {
+	Name string
+	Value string
+}
+
+func (l *Statistics) List() ([]Statistic, error) {
+	var stats []Statistic
+
+	result, err := l.i.nsenter.Curl(l.endpoints.dump)
+	if err != nil { return stats, err }
+
+	ss := strings.Split(result, "\n")
+	sort.Strings(ss)
+	for _, s := range ss {
+		stat := strings.Split(s, ": ")
+		if len(stat) < 2 { continue }
+
+		stats = append(stats, Statistic{
+			Name: stat[0],
+			Value: stat[1],
+		})
+	}
+
+	return stats, nil
 }

--- a/output/formatter.go
+++ b/output/formatter.go
@@ -1,0 +1,57 @@
+package output
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+const (
+	formatText = "text"
+	formatJson = "json"
+)
+
+type Formatter interface {
+	Format(o interface{}) (string, error)
+}
+
+func NewFormatter(format string) (formatter Formatter, err error)  {
+	switch format {
+	case formatText:
+		formatter = NewTextFormatter()
+	case formatJson:
+		formatter = NewJsonFormatter()
+	default:
+		err = fmt.Errorf("unknown format: %s", format)
+	}
+	return formatter, err
+}
+
+// Text formatting
+type TextFormatter struct {}
+
+func NewTextFormatter() Formatter {
+	return &TextFormatter{}
+}
+
+func (f *TextFormatter) Format(o interface{}) (string, error) {
+	switch o.(type) {
+	case string:
+		return fmt.Sprint(o), nil
+	default:
+		return fmt.Sprintf("%v", o), nil
+	}
+}
+
+// JSON formatter
+type JsonFormatter struct {}
+
+func NewJsonFormatter() Formatter {
+	return &JsonFormatter{}
+}
+
+func (f *JsonFormatter) Format(o interface{}) (string, error) {
+	b, err := json.MarshalIndent(o, "", "  ")
+	if err != nil { return "", err }
+
+	return fmt.Sprint(string(b)), nil
+}


### PR DESCRIPTION
## What?

Allows `-o json` to format output as JSON. This allows us the ability to programmatically consume Bonvoy output.

This does this primarily using `json.Unmarshal`, and letting golang do its thing there, by creating Response structs for each command, and utilizing a central Formatter struct for handling command responses. I override the Response struct `String()` method to allow non-json output as well.

## Proof of Life

```
root@youngeducated-cloud-dev-cdvm:~# bonvoy clusters list content-hutch -o json
{
  "service": "content-hutch",
  "envoy": {
    "pid": 10947,
    "nomad_allocation_id": "2fa88fd2-d31c-fa23-c66c-8ee2f29743cf"
  },
  "statistics": {
    "bcapp.default.youngeducated.internal.89749198-098b-d4bc-802b-04d28ed8af0a.consul": {
      "host": "bcapp.default.youngeducated.internal.89749198-098b-d4bc-802b-04d28ed8af0a.consul",
      "outlier": {
        "success_rate_average": "-1",
        "success_rate_ejection_threshold": "-1",
        "local_origin_success_rate_average": "
```

And so forth, for each command.

----

@mattclement @joshdurbin @chrisboulton 