### PR TITLE
INFRA-6997: Adjust envoy default address to 127.0.0.2

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -4,7 +4,7 @@ import "github.com/spf13/viper"
 
 func Load() {
 	viper.AutomaticEnv()
-	viper.SetDefault("ENVOY_HOST", "http://0.0.0.0:19001")
+	viper.SetDefault("ENVOY_HOST", "http://127.0.0.2:19001")
 	viper.SetDefault("CONSUL_API_HOST", "http://0.0.0.0:8500")
 	viper.SetDefault("NOMAD_ADDR", "https://0.0.0.0:4646")
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -8,7 +8,7 @@ import (
 func TestConfig_Load(t *testing.T) {
 	Load()
 	eh := viper.GetString("ENVOY_HOST")
-	if eh != "http://0.0.0.0:19001" {
+	if eh != "http://127.0.0.2:19001" {
 		t.Error("Default ENVOY_HOST is incorrect:", eh)
 	}
 	eh = viper.GetString("CONSUL_API_HOST")

--- a/envoy/instance_test.go
+++ b/envoy/instance_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestGetDefaultHost(t *testing.T) {
 	t.Run("Test GetHost == ENVOY_HOST", func(t *testing.T) {
-		testAddr := "http://0.0.0.0:19000"
+		testAddr := "http://127.0.0.2:19000"
 		viper.Set("ENVOY_HOST", testAddr)
 		if GetDefaultHost() != testAddr {
 			t.Error("ENVOY_HOST does not match")


### PR DESCRIPTION
HashiCorp changed this in Nomad 1.1.3.

https://github.com/hashicorp/nomad/commit/ee7d32fb98313ec3a770f5869d937b15c92cb3c2

This makes this the new default.

---

@bigcommerce/infra-engineering 